### PR TITLE
Fix `use_watering_can` advancement

### DIFF
--- a/src/main/resources/data/additionaladditions/advancements/use_watering_can.json
+++ b/src/main/resources/data/additionaladditions/advancements/use_watering_can.json
@@ -19,9 +19,14 @@
     "use": {
       "trigger": "minecraft:item_used_on_block",
       "conditions": {
-        "item": {
-          "items": ["additionaladditions:watering_can"]
-        }
+        "location": [
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "items": ["additionaladditions:watering_can"]
+            }
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
Fixed according to format on wiki: https://minecraft.wiki/w/Advancement_definition#minecraft:item_used_on_block.

Fixes this error:
```log
[Render thread/ERROR]: Parsing error loading custom advancement additionaladditions:use_watering_can: Failed to parse 'location' field
```

